### PR TITLE
enhance replaceReducer with optional nextState parameter

### DIFF
--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -97,7 +97,7 @@ type Store = {
   dispatch: Dispatch
   getState: () => State
   subscribe: (listener: () => void) => () => void
-  replaceReducer: (reducer: Reducer) => void
+  replaceReducer: (reducer: Reducer, state: ?State) => void
 }
 ```
 
@@ -107,7 +107,7 @@ There should only be a single store in a Redux app, as the composition happens o
 - [`dispatch(action)`](api/Store.md#dispatch) is the base dispatch function described above.
 - [`getState()`](api/Store.md#getState) returns the current state of the store.
 - [`subscribe(listener)`](api/Store.md#subscribe) registers a function to be called on state changes.
-- [`replaceReducer(nextReducer)`](api/Store.md#replaceReducer) can be used to implement hot reloading and code splitting. Most likely you won’t use it.
+- [`replaceReducer(nextReducer, nextState)`](api/Store.md#replaceReducer) can be used to implement hot reloading and code splitting. Most likely you won’t use it.
 
 See the complete [store API reference](api/Store.md#dispatch) for more details.
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -18,7 +18,7 @@ This section documents the complete Redux API. Keep in mind that Redux is only c
   * [getState()](Store.md#getState)
   * [dispatch(action)](Store.md#dispatch)
   * [subscribe(listener)](Store.md#subscribe)
-  * [replaceReducer(nextReducer)](Store.md#replaceReducer)
+  * [replaceReducer(nextReducer, nextState)](Store.md#replaceReducer)
 
 ### Importing
 

--- a/docs/api/Store.md
+++ b/docs/api/Store.md
@@ -15,7 +15,7 @@ To create it, pass your root [reducing function](../Glossary.md#reducer) to [`cr
 - [`getState()`](#getState)
 - [`dispatch(action)`](#dispatch)
 - [`subscribe(listener)`](#subscribe)
-- [`replaceReducer(nextReducer)`](#replaceReducer)
+- [`replaceReducer(nextReducer, nextState)`](#replaceReducer)
 
 ## Store Methods
 
@@ -125,12 +125,14 @@ handleChange()
 
 <hr>
 
-### <a id='replaceReducer'></a>[`replaceReducer(nextReducer)`](#replaceReducer)
+### <a id='replaceReducer'></a>[`replaceReducer(nextReducer, nextState)`](#replaceReducer)
 
 Replaces the reducer currently used by the store to calculate the state.
+An optioanal nexState used to extend current state with keys for the nextReducer.
 
 It is an advanced API. You might need this if your app implements code splitting, and you want to load some of the reducers dynamically. You might also need this if you implement a hot reloading mechanism for Redux.
 
 #### Arguments
 
 1. `reducer` (*Function*) The next reducer for the store to use.
+2. `nextState` (*Object*) The next state for the nextReducer.

--- a/index.d.ts
+++ b/index.d.ts
@@ -181,8 +181,9 @@ export interface Store<S> {
    * implement a hot reloading mechanism for Redux.
    *
    * @param nextReducer The reducer for the store to use instead.
+   * @param nextState New state for the nextReducer.
    */
-  replaceReducer(nextReducer: Reducer<S>): void;
+  replaceReducer(nextReducer: Reducer<S>, nextState: S): void;
 }
 
 /**

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -187,12 +187,26 @@ export default function createStore(reducer, initialState, enhancer) {
    * load some of the reducers dynamically. You might also need this if you
    * implement a hot reloading mechanism for Redux.
    *
+   * Optionally you can pass an new state, enhanced with state for keys
+   * in the nextReducer.
+   * It useful for code splitting when injecting reducers for a page chunk after
+   * server-side rendering the page to recover state in a browser.
+   *
    * @param {Function} nextReducer The reducer for the store to use instead.
+   * @param {Object} nextState New state for the nextReducer.
    * @returns {void}
    */
-  function replaceReducer(nextReducer) {
+  function replaceReducer(nextReducer, nextState) {
     if (typeof nextReducer !== 'function') {
       throw new Error('Expected the nextReducer to be a function.')
+    }
+
+    if (typeof nextState !== 'undefined') {
+      if (nextState && typeof nextState !== 'object') {
+        throw new Error('Expected the nextState to be an object.')
+      }
+
+      currentState = Object.assign({}, currentState, nextState)
     }
 
     currentReducer = nextReducer


### PR DESCRIPTION
It helps to recover app state which is rendered on server as sync app, but client is built as code-splitted app.

Each dynamic module injects its reducers when it has been loaded.
But at the moment clients store is initialized with only root reducers from root module and store state lost most of the data from the server.

**_nextState_** parameters helps to recover server state for those code-splitted app at the first render